### PR TITLE
Make the SortedEntityComponentArray iterable.

### DIFF
--- a/core/src/com/goonsquad/galactictd/systems/graphics/RenderSystem.java
+++ b/core/src/com/goonsquad/galactictd/systems/graphics/RenderSystem.java
@@ -63,7 +63,7 @@ public abstract class RenderSystem extends BaseEntitySystem {
 
     @Override
     protected void processSystem() {
-        for (int entityId : sortedEs.getSortedEntityIds()) {
+        for (int entityId : sortedEs) {
             entityPosition = positionComponentMapper.get(entityId);
             entityRenderable = renderableComponentMapper.get(entityId);
             batch.setColor(entityRenderable.r, entityRenderable.g, entityRenderable.b, entityRenderable.a);

--- a/core/src/com/goonsquad/galactictd/systems/input/TouchConsumerSystem.java
+++ b/core/src/com/goonsquad/galactictd/systems/input/TouchConsumerSystem.java
@@ -74,7 +74,7 @@ public abstract class TouchConsumerSystem extends BaseEntitySystem implements In
         Position entityPosition;
         Touchable entityTouch;
 
-        for (int id : sortedEs.getSortedEntityIds()) {
+        for (int id : sortedEs) {
             entityTouch = touchableComponentMapper.get(id);
             if (entityTouch.acceptingTouch) {
                 entityPosition = positionComponentMapper.get(id);

--- a/core/src/com/goonsquad/galactictd/systems/utils/SortedEntityComponentArray.java
+++ b/core/src/com/goonsquad/galactictd/systems/utils/SortedEntityComponentArray.java
@@ -72,12 +72,6 @@ public class SortedEntityComponentArray<E extends Component> implements Iterator
 
     }
 
-    //TODO
-    //Set up class so that a new array does not have to be created when needed.
-    public int[] getSortedEntityIds() {
-        return Arrays.copyOf(sortedEntityIds, size);
-    }
-
     @Override
     public boolean hasNext() {
         return iteratingPosition + 1 < size;

--- a/core/src/com/goonsquad/galactictd/systems/utils/SortedEntityComponentArray.java
+++ b/core/src/com/goonsquad/galactictd/systems/utils/SortedEntityComponentArray.java
@@ -82,8 +82,7 @@ public class SortedEntityComponentArray<E extends Component> implements Iterator
         if (iteratingPosition + 1 >= size) {
             throw new NoSuchElementException();
         }
-        iteratingPosition++;
-        return this.sortedEntityIds[iteratingPosition];
+        return this.sortedEntityIds[++iteratingPosition];
     }
 
     @Override

--- a/core/src/com/goonsquad/galactictd/systems/utils/SortedEntityComponentArray.java
+++ b/core/src/com/goonsquad/galactictd/systems/utils/SortedEntityComponentArray.java
@@ -5,9 +5,12 @@ import com.artemis.ComponentMapper;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 
-public class SortedEntityComponentArray<E extends Component> {
+public class SortedEntityComponentArray<E extends Component> implements Iterator<Integer>, Iterable<Integer> {
     private int[] sortedEntityIds;
+    private int iteratingPosition;
     private int size;
     private Comparator comparator;
     private ComponentMapper mapper;
@@ -73,5 +76,25 @@ public class SortedEntityComponentArray<E extends Component> {
     //Set up class so that a new array does not have to be created when needed.
     public int[] getSortedEntityIds() {
         return Arrays.copyOf(sortedEntityIds, size);
+    }
+
+    @Override
+    public boolean hasNext() {
+        return iteratingPosition + 1 < size;
+    }
+
+    @Override
+    public Integer next() {
+        if (iteratingPosition + 1 >= size) {
+            throw new NoSuchElementException();
+        }
+        iteratingPosition++;
+        return this.sortedEntityIds[iteratingPosition];
+    }
+
+    @Override
+    public Iterator<Integer> iterator() {
+        this.iteratingPosition = -1;
+        return this;
     }
 }


### PR DESCRIPTION
Do this so that a new array of entity Ids is no longer created and returned every time a SortedEntityComponentArray needs to be iterated over. Needs reviewed.
